### PR TITLE
Fix handling Non Carbon Server std out lines starting with '['

### DIFF
--- a/cc.py
+++ b/cc.py
@@ -22,7 +22,7 @@ colourMap = {"unknownLine": 6,
 
 
 def processLine(line):
-    if line.startswith("["):
+    if re.match("\[\d{4}-\d{2}-\d{2}", line):
         processLogLine(line)
     elif line.startswith("\t") or re.match("[a-zA-Z][\w\.]*: ", line):
         processException(line)


### PR DESCRIPTION
Fix handling std out lines starting with '[' but are not generated by Carbon Server directly.

This fixes the same issue that has been highlighted in https://github.com/manuranga/colour-carbon/issues/2

This happens in APIM 2.0.0 after MB features were added so it recreates the same issue that has been logged. Internal 3rd Party libraries used by MB print following to std output,

[Broker] BRK-1001 : Startup : Version: 0.11 Build: 90784:90849
[Broker] MNG-1001 : Startup
[Broker] MNG-1004 : Ready : Using the platform JMX Agent

The current logic to recognize normal lines printed by the Carbon Server is any line that begins with '[' character. This assumption breaks in above case when we have lines beginning with '[' but are not generated by Carbon Server directly(hence do not follow standard logging format of Carbon Server leading to the exception).

The fix checks additionally for the 'yyyy-mm-dd' date format existing following the '[' character to evaluate if output is from the Carbon Server. This matches the Carbon Servers format of standard output which begins with the characters '[yyyy-mm-dd'