### PR TITLE
Add support for detecting startup script of C5 servers

### DIFF
--- a/cc.py
+++ b/cc.py
@@ -113,7 +113,13 @@ if path.isfile(configPath):
 
 ############## Main ###############
 
-args = ["./bin/wso2server.sh"] + sys.argv[1:]
+startupScript = "./bin/wso2server.sh"
+
+# If this is a C5 server
+if not path.isfile(startupScript):
+    startupScript = "./bin/carbon.sh"
+
+args = [startupScript] + sys.argv[1:]
 process = subprocess.Popen(args, stdout=subprocess.PIPE)
 for line in iter(process.stdout.readline, ''):
     processLine(line)


### PR DESCRIPTION
On C5 servers the startup script is named **carbon.sh**, so colour-carbon will assume the server is C5 if the _wso2server.sh_ does not exist and attempt to start using the C5 script.
